### PR TITLE
Do not silently truncate the key if it is too long

### DIFF
--- a/port.c
+++ b/port.c
@@ -87,8 +87,10 @@ macaroon_hmac(const unsigned char* _key, size_t _key_sz,
     int rc;
     unsigned char key[crypto_auth_hmacsha256_KEYBYTES];
 
+    assert(_key_sz <= sizeof(key));
+
     sodium_memzero(key, crypto_auth_hmacsha256_BYTES);
-    memmove(key, _key, _key_sz < sizeof(key) ? _key_sz : sizeof(key));
+    memmove(key, _key, _key_sz);
     rc = crypto_auth_hmacsha256(hash, text, text_sz, key);
     assert(rc == 0);
     return 0;


### PR DESCRIPTION
Previously, the length argument passed to memmove was min(sizeof(buffer), input_size), which will silently truncate the key if it is larger than the buffer. This should be a hard failure instead.

It's unclear to me whether it is better to use an assertion, which might be disabled at compile time, or to return -1. Please advise.
