### PR TITLE
returncode should match return value.

### DIFF
--- a/macaroons.c
+++ b/macaroons.c
@@ -876,10 +876,6 @@ macaroon_verify_inner(const struct macaroon_verifier* V,
     data = M->signature.data;
     tree_fail |= parse_signature_packet(&M->signature, &data);
     tree_fail |= macaroon_memcmp(data, csig, MACAROON_HASH_BYTES);
-    if (tree_fail)
-    {
-        *err = MACAROON_NOT_AUTHORIZED;
-    }
     return tree_fail;
 }
 
@@ -910,6 +906,11 @@ macaroon_verify_raw(const struct macaroon_verifier* V,
     assert(key_sz == MACAROON_SUGGESTED_SECRET_LENGTH);
     rc = macaroon_verify_inner(V, M, M, key, key_sz,
                                MS, MS_sz, err, tree, 0);
+    if (rc)
+    {
+        *err = MACAROON_NOT_AUTHORIZED;
+    }
+
     free(tree);
     return rc;
 }

--- a/macaroons.h
+++ b/macaroons.h
@@ -52,7 +52,7 @@ struct macaroon_verifier;
 
 enum macaroon_returncode
 {
-    MACAROON_SUCCESS          = 0,
+    MACAROON_SUCCESS          = 2048,
     MACAROON_OUT_OF_MEMORY    = 2049,
     MACAROON_HASH_FAILED      = 2050,
     MACAROON_INVALID          = 2051,


### PR DESCRIPTION
Fix a few spots where the macaroon_returncode err does not match the
actual status of whether the operation was successful.

Change MACAROON_SUCCESS to 0, so that non-zero always indicates error.
