### PR TITLE
Change vid encoding so that we only encode to base 64 on serialization.

### DIFF
--- a/README
+++ b/README
@@ -478,7 +478,7 @@ Here's what this looks like in code:
     cid this was how we remind auth of key/pred
     vid AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA027FAuBYhtHwJ58FX6UlVNFtFsGxQHS7uD/w/dedwv4Jjw7UorCREw5rXbRqIKhr
     cl http://auth.mybank/
-    signature 6b99edb2ec6d7a4382071d7d41a0bf7dfa27d87d2f9fea86e330d7850ffda2b2
+    signature d27db2fd1f22760e4c3dae8137e2d8fc1df6c0741c18aed4b97256bf78d1f55c
 
 We now have a macaroon with a third-party caveat.  The most interesting thing to
 note about this macaroon is that it includes no information that reveals the
@@ -534,7 +534,7 @@ would see that the binding process has irreversibly altered their signature(s).
     >>> D.signature
     '82a80681f9f32d419af12f6a71787a1bac3ab199df934ed950ddf20c25ac8c65'
     >>> DP.signature
-    'b38b26ab29d3724e728427e758cccc16d9d7f3de46d0d811b70b117b05357b9b'
+    '2eb01d0dd2b4475330739140188648cf25dda0425ea9f661f1574ca0a9eac54e'
 
 The root macaroon ``M'' and its discharge macaroons ``MS'' are ready for the
 request.  Alice can serialize them all and send them to the bank to prove she is

--- a/packet.c
+++ b/packet.c
@@ -188,13 +188,6 @@ serialize_packet(const struct packet* from,
     return ptr + from->size;
 }
 
-char*
-inspect_packet(const struct packet* from, char* ptr)
-{
-    memmove(ptr, from->data + PACKET_PREFIX, from->size - PACKET_PREFIX);
-    return ptr + from->size - PACKET_PREFIX;
-}
-
 int
 copy_if_parses(const unsigned char** rptr,
                const unsigned char* const end,
@@ -285,11 +278,11 @@ parse_identifier_packet(const struct packet* packet,
 }
 
 unsigned char*
-create_signature_packet(const unsigned char* signature,
+create_signature_packet(const unsigned char* signature, size_t signature_sz,
                         struct packet* pkt, unsigned char* ptr)
 {
     return create_kv_packet((const unsigned char*)SIGNATURE, SIGNATURE_SZ,
-                            signature, MACAROON_HASH_BYTES, pkt, ptr);
+                            signature, signature_sz, pkt, ptr);
 }
 
 int

--- a/packet.h
+++ b/packet.h
@@ -75,8 +75,6 @@ copy_packet(const struct packet* from,
 unsigned char*
 serialize_packet(const struct packet* from,
                  unsigned char* ptr);
-char*
-inspect_packet(const struct packet* from, char* ptr);
 int
 copy_if_parses(const unsigned char** rptr,
                const unsigned char* const end,
@@ -103,7 +101,7 @@ parse_identifier_packet(const struct packet* pkt,
 
 /* create a signature packet */
 unsigned char*
-create_signature_packet(const unsigned char* signature,
+create_signature_packet(const unsigned char* signature, size_t sig_sz,
                         struct packet* pkt, unsigned char* ptr);
 int
 parse_signature_packet(const struct packet* pkt,

--- a/port.c
+++ b/port.c
@@ -131,7 +131,10 @@ macaroon_hex2bin(const char* hex, size_t hex_sz, unsigned char* bin)
     const char* tmp = NULL;
     unsigned byte;
 
-    assert(!(hex_sz & 1));
+    if(hex_sz & 1)
+    {
+        return -1;
+    }
 
     for (idx = 0; idx < hex_sz; idx += 2)
     {

--- a/port.h
+++ b/port.h
@@ -33,7 +33,17 @@
 
 #define MACAROON_SECRET_KEY_BYTES 32U
 #define MACAROON_SECRET_NONCE_BYTES 24U
+
+/*
+ * The number of zero bytes required by crypto_secretbox
+ * before the plaintext.
+ */
 #define MACAROON_SECRET_TEXT_ZERO_BYTES 32U
+
+/*
+ * The number of zero bytes placed by crypto_secretbox
+ * before the ciphertext
+ */
 #define MACAROON_SECRET_BOX_ZERO_BYTES 16U
 
 void


### PR DESCRIPTION
This made some existing logic feel more difficult than it should,
so added enum encoding and encode and decode methods
to make it easier to make encoding transformations.

Added a couple of TODOs - one as a reminder that JSON deserialisation
is incomplete, the other because I did not understand the code.

Also changed a couple of asserts to runtime checks (more
are needed).

Signature serialization becomes a little more regular.

I've tried to keep to the existing code style, but there are inevitably
going to be some slip-ups. There were some trade-offs of
minimal allocation vs code simplicity (notably in inspect_packet,
which allocates much more than before, but I suspect it's
not likely to be a bottleneck).
