### PR TITLE
Convert `u_char` instances to `unsigned char` to improve portability

### DIFF
--- a/base64.c
+++ b/base64.c
@@ -123,14 +123,14 @@ static const char Pad64 = '=';
 
 int
 b64_ntop(src, srclength, target, targsize)
-	u_char const *src;
+	unsigned char const *src;
 	size_t srclength;
 	char *target;
 	size_t targsize;
 {
 	size_t datalength = 0;
-	u_char input[3];
-	u_char output[4];
+	unsigned char input[3];
+	unsigned char output[4];
 	size_t i;
 
 	while (2 < srclength) {
@@ -188,12 +188,12 @@ b64_ntop(src, srclength, target, targsize)
 int
 b64_pton(src, target, targsize)
 	char const *src;
-	u_char *target;
+	unsigned char *target;
 	size_t targsize;
 {
     size_t tarindex;
 	int state, ch;
-	u_char nextbyte;
+	unsigned char nextbyte;
 	char *pos;
 
 	state = 0;


### PR DESCRIPTION
`u_char` is not in the C standard, and so this fails to build on OSX.
It could be fixed by including `sys/types.h`, but it seems easier just
to write it out as `unsigned char` instead of pulling in yet another
header file.
