### PR TITLE
FIX enc_ciphertext has to be the same length as enc_plaintext

### DIFF
--- a/macaroons.c
+++ b/macaroons.c
@@ -345,7 +345,7 @@ macaroon_add_third_party_caveat_raw(const struct macaroon* N,
     const unsigned char *old_sig;
     unsigned char enc_nonce[MACAROON_SECRET_NONCE_BYTES];
     unsigned char enc_plaintext[MACAROON_SECRET_TEXT_ZERO_BYTES + MACAROON_HASH_BYTES];
-    unsigned char enc_ciphertext[MACAROON_SECRET_BOX_ZERO_BYTES + MACAROON_HASH_BYTES];
+    unsigned char enc_ciphertext[MACAROON_SECRET_TEXT_ZERO_BYTES + MACAROON_HASH_BYTES];
     unsigned char vid[VID_NONCE_KEY_SZ];
     size_t i;
     size_t sz;


### PR DESCRIPTION
Hi,

while porting last changes from libmacaroons to jmacaroons (Java port),
I've discovered, that the buffers enc_ciphertext and enc_plaintext differs in size.
IMHO, the crypto_secretbox_xsalsa20poly1305 is a symmetric cipher,
which needs to have same sizes for ciphertext and plaintext buffers.
Else, this may result in a buffer overflow.

I'm not a crypto expert, so can anyone confirm this?

Regards
Martin
