### PR TITLE
Fixed: fill the nonce with random bytes before handing over to secretbox

### DIFF
--- a/macaroons.c
+++ b/macaroons.c
@@ -375,7 +375,7 @@ macaroon_add_third_party_caveat_raw(const struct macaroon* N,
         return NULL;
     }
 
-    macaroon_memzero(enc_nonce, sizeof(enc_nonce)); /* XXX get some random bytes instead */
+    macaroon_randombytes(enc_nonce, sizeof(enc_nonce));
     macaroon_memzero(enc_plaintext, sizeof(enc_plaintext));
     macaroon_memzero(enc_ciphertext, sizeof(enc_ciphertext));
 

--- a/port.c
+++ b/port.c
@@ -38,6 +38,7 @@
 #include <sodium/crypto_auth_hmacsha256.h>
 #include <sodium/crypto_secretbox_xsalsa20poly1305.h>
 #include <sodium/utils.h>
+#include <sodium/randombytes.h>
 
 /* macaroons */
 #include "port.h"
@@ -81,6 +82,12 @@ int
 macaroon_memcmp(const void* data1, const void* data2, size_t data_sz)
 {
     return sodium_memcmp(data1, data2, data_sz);
+}
+
+int
+macaroon_randombytes(void* data, const size_t data_sz) {
+    randombytes_buf(data, data_sz);
+    return 0;
 }
 
 int

--- a/port.h
+++ b/port.h
@@ -53,6 +53,9 @@ int
 macaroon_memcmp(const void* data1, const void* data2, size_t data_sz);
 
 int
+macaroon_randombytes(void* data, const size_t data_sz);
+
+int
 macaroon_hmac(const unsigned char* key, size_t key_sz,
               const unsigned char* text, size_t text_sz,
               unsigned char* hash);


### PR DESCRIPTION
This is a must, as described in 'security model' of secret box http://nacl.cr.yp.to/secretbox.html

I've used sodium/random, because it's target platform aware.
Feedback is welcome.
