### PR TITLE
Less cryptic error message when pkg-config is missing

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -24,6 +24,17 @@ AC_PROG_CXX
 
 ANAL_WARNINGS
 
+dnl Testing presence of pkg-config
+AC_MSG_CHECKING([pkg-config m4 macros])
+if test m4_ifdef([PKG_CHECK_MODULES], [yes], [no]) == yes; then
+	AC_MSG_RESULT([yes]);
+else
+	AC_MSG_RESULT([no]);
+	AC_MSG_ERROR([
+pkg-config is required.
+See pkg-config.freedesktop.org])
+fi
+
 # Checks for libraries.
 PKG_CHECK_MODULES([SODIUM], [libsodium >= 0.4])
 


### PR DESCRIPTION
Taken from  https://github.com/brianb/mdbtools/commit/4b08559d663acd7d9ff44fc520948f21d34c33b3
