### PR TITLE
OS X Compilation Fix

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -32,6 +32,7 @@ AC_SUBST([BSDLIBS], [$BSDLIB])
 AC_CHECK_HEADER([libutil.h],[AC_DEFINE([HAVE_LIBUTIL_H],[1],[Define to 1 if you have the <libutil.h> header file.])],,)
 AC_CHECK_HEADER([bsd/stdlib.h],[AC_DEFINE([HAVE_BSD_STDLIB_H],[1],[Define to 1 if you have the <bsd/stdlib.h> header file.])],,)
 AC_CHECK_HEADER([bsd/libutil.h],[AC_DEFINE([HAVE_BSD_LIBUTIL_H],[1],[Define to 1 if you have the <bsd/libutil.h> header file.])],,)
+AC_CHECK_HEADER([util.h],[AC_DEFINE([HAVE_OSX_LIBUTIL_H],[1],[Define to 1 if you have the <util.h> header file.])],,)
 
 # Checks for typedefs, structures, and compiler characteristics.
 AC_TYPE_SIZE_T

--- a/macaroons.c
+++ b/macaroons.c
@@ -42,6 +42,8 @@
 #include <libutil.h>
 #elif HAVE_BSD_LIBUTIL_H
 #include <bsd/libutil.h>
+#elif HAVE_OSX_LIBUTIL_H
+#include <util.h>
 #else
 #error portability problem
 #endif


### PR DESCRIPTION
Here is a OS X compilation fix about the missing libutil.h. Fixes issue #37.