### PR TITLE
Provide libsodium with the correct buffer size.

### DIFF
--- a/port.c
+++ b/port.c
@@ -126,7 +126,7 @@ macaroon_secretbox_open(const unsigned char* enc_key,
 void
 macaroon_bin2hex(const unsigned char* bin, size_t bin_sz, char* hex)
 {
-    void* ptr = sodium_bin2hex(hex, bin_sz * 2, bin, bin_sz);
+    void* ptr = sodium_bin2hex(hex, bin_sz * 2 + 1, bin, bin_sz);
     assert(ptr == hex);
 }
 


### PR DESCRIPTION
`bin2hex` in libsodium appends a null-character to the output array, meaning the hex array must be `2 * (sizeof bin array) + 1` characters long.

Within libmacaroons, that appears to be the actual buffer size -- but we were passing this incorrectly to libsodium.  In newer versions of libsodium, this triggers an internal assert.