### PR TITLE
Initialize empty structs to void missing data being serialized to JSON.

### DIFF
--- a/v2.c
+++ b/v2.c
@@ -859,10 +859,10 @@ j2b_macaroon(char** ptr, char* end,
              enum macaroon_returncode* err)
 {
     struct macaroon* M = NULL;
-    struct slice s;
-    struct slice location;
-    struct slice identifier;
-    struct slice signature;
+    struct slice s = EMPTY_SLICE;
+    struct slice location = EMPTY_SLICE;
+    struct slice identifier = EMPTY_SLICE;
+    struct slice signature = EMPTY_SLICE;
     int seen_location = 0;
     int seen_identifier = 0;
     int seen_signature = 0;


### PR DESCRIPTION
When serializing a macaroon to the V2 JSON format, any fields which are not utilized (such as when serializing a discharge macaroon) result in garbage data being emitted.

The patch simply initializes the fields with empty data, which is then filtered out.