### PR TITLE
Free memory for temporary data buffer.

### DIFF
--- a/macaroons.c
+++ b/macaroons.c
@@ -1741,6 +1741,7 @@ macaroon_deserialize(const char* _data, enum macaroon_returncode* err)
         return NULL;
     }
 
+    free(data);
     *err = MACAROON_SUCCESS;
     return M;
 }


### PR DESCRIPTION
With this, deserializing the macaroon no longer leaks the buffer on success.  Valgrind now appears to be happy with libmacaroons.